### PR TITLE
Fix/video border radius

### DIFF
--- a/packages/web/src/client/components/Blocks/BlockApproach.tsx
+++ b/packages/web/src/client/components/Blocks/BlockApproach.tsx
@@ -30,7 +30,7 @@ const Section = styled(FadeIn, {
 })
 
 const BlockMedia = styled(Media, {
-  borderRadius: '$wrapperLarge',
+  br: '$wrapperLarge',
   mb: '$l',
 
   '@tabletUp': {

--- a/packages/web/src/client/components/Blocks/BlocksCarousel/index.tsx
+++ b/packages/web/src/client/components/Blocks/BlocksCarousel/index.tsx
@@ -225,10 +225,10 @@ const Container = styled('div', {
   width: '100%',
   position: 'relative',
   overflow: 'hidden',
-  borderRadius: '$wrapperMobile',
+  br: '$wrapperMobile',
 
   '@tabletUp': {
-    borderRadius: '$wrapper',
+    br: '$wrapper',
   },
 })
 

--- a/packages/web/src/client/components/Cards/CardHome.tsx
+++ b/packages/web/src/client/components/Cards/CardHome.tsx
@@ -131,7 +131,7 @@ export const CardHome = (props: CardHomeProps) => {
 const CardWrapper = styled('a', {
   display: 'block',
   position: 'relative',
-  borderRadius: '$wrapperLarge',
+  br: '$wrapperLarge',
   overflow: 'hidden',
 
   variants: {
@@ -173,7 +173,7 @@ const ImageContainer = styled(animated.div, {
 })
 
 const MediaContainer = styled(Media, {
-  borderRadius: '$wrapperLarge',
+  br: '$wrapperLarge',
   overflow: 'hidden',
 })
 

--- a/packages/web/src/client/components/Grids/GridTeam.tsx
+++ b/packages/web/src/client/components/Grids/GridTeam.tsx
@@ -64,9 +64,9 @@ const GridItemContainer = styled(FadeIn, {
 const GridImage = styled(Media, {
   width: '100%',
   mb: '$xxs',
-  borderRadius: '$wrapper',
+  br: '$wrapper',
 
   '@tabletUp': {
-    borderRadius: '$wrapperLarge',
+    br: '$wrapperLarge',
   },
 })

--- a/packages/web/src/client/components/ImageStrip/ImageStrip.tsx
+++ b/packages/web/src/client/components/ImageStrip/ImageStrip.tsx
@@ -132,7 +132,7 @@ const ImageStripContainer = styled(FadeIn, {
 })
 
 const ImageWrapper = styled('div', {
-  borderRadius: '$wrapperLarge',
+  br: '$wrapperLarge',
   overflow: 'hidden',
 })
 

--- a/packages/web/src/client/components/OpeningText/OpeningText.tsx
+++ b/packages/web/src/client/components/OpeningText/OpeningText.tsx
@@ -50,6 +50,10 @@ const LogoContainer = styled('div', {
   width: '8rem',
   mb: '$s',
 
+  '& > svg': {
+    width: '100%',
+  },
+
   '@tabletUp': {
     width: '13.8rem',
     mb: '$m',

--- a/packages/web/src/client/styles/stitches.config.ts
+++ b/packages/web/src/client/styles/stitches.config.ts
@@ -159,6 +159,13 @@ const { styled, globalCss, getCssText, config, keyframes, reset } =
         marginTop: value,
         marginBottom: value,
       }),
+      br: (value: Stitches.PropertyValue<'borderRadius'>) => ({
+        borderRadius: value,
+        // Safari requires this to be explicitly set on videos
+        video: {
+          borderRadius: value,
+        },
+      }),
       debug: (value: Stitches.PropertyValue<'color'>) => ({
         border: `solid 1px ${value}`,
       }),


### PR DESCRIPTION
### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

- resolves #177 
- Border radius is not applied to the actual media element on safari

### What

<!-- what have you done, if its a bug, whats your solution? -->

- adds util function that adds the border radius value to `video` elements

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- feel free to add additional comments -->
