### PR TITLE
fix: carousel dots missing

### DIFF
--- a/packages/web/src/client/components/Blocks/BlocksCarousel/index.tsx
+++ b/packages/web/src/client/components/Blocks/BlocksCarousel/index.tsx
@@ -177,7 +177,9 @@ export const Carousel = (props: Sanity.BlockMedia) => {
         <Caption>
           {items[activeIndex].caption ? (
             <CaptionText>{items[activeIndex].caption}</CaptionText>
-          ) : null}
+          ) : (
+            <CaptionText />
+          )}
           {!video && itemCount > 1 && (
             <Dots>
               {items.map((_, index) => (
@@ -252,7 +254,7 @@ const Dot = styled('div', {
   width: 6,
   height: 6,
   borderRadius: '$circle',
-  backgroundColor: '$darkBlue',
+  backgroundColor: '$blue100',
 
   '& + &': {
     ml: '$xxxs',

--- a/packages/web/src/client/components/Blocks/BlocksCarousel/index.tsx
+++ b/packages/web/src/client/components/Blocks/BlocksCarousel/index.tsx
@@ -175,11 +175,7 @@ export const Carousel = (props: Sanity.BlockMedia) => {
           )}
         </Container>
         <Caption>
-          {items[activeIndex].caption ? (
-            <CaptionText>{items[activeIndex].caption}</CaptionText>
-          ) : (
-            <CaptionText />
-          )}
+          {<CaptionText>{items[activeIndex].caption}</CaptionText>}
           {!video && itemCount > 1 && (
             <Dots>
               {items.map((_, index) => (

--- a/packages/web/src/client/components/Blocks/BlocksCarousel/index.tsx
+++ b/packages/web/src/client/components/Blocks/BlocksCarousel/index.tsx
@@ -254,7 +254,7 @@ const Dot = styled('div', {
   width: 6,
   height: 6,
   borderRadius: '$circle',
-  backgroundColor: '$blue100',
+  backgroundColor: '$black100',
 
   '& + &': {
     ml: '$xxxs',


### PR DESCRIPTION
### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
Resolves #184 

### What

<!-- what have you done, if its a bug, whats your solution? -->
- changed the variable that was passed into the `backgroundColor` with the updated `blue100` from the `stitches` configuration file
- so that I can always keep the 3 dots on the right side of the carousel and not moving, I always have the `CaptionText` rendering even when it has no text inside. This keeps the layout consistent.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Ready to be merged

<!-- feel free to add additional comments -->
