### PR TITLE
fix: removing bottom padding

### DIFF
--- a/packages/web/src/client/components/Button/Button.tsx
+++ b/packages/web/src/client/components/Button/Button.tsx
@@ -54,7 +54,6 @@ export const ButtonContainer = styled('span', {
   display: 'inline-block',
   borderRadius: '$pill',
   p: '$xxs',
-  pb: 9,
   textDecoration: 'none',
   cursor: 'pointer',
   fontSize: '$XS',


### PR DESCRIPTION
from `view` button in the home cards. The padding is 8px all round now.

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
Resolves #191 

### What

<!-- what have you done, if its a bug, whats your solution? -->
removed the bottom padding that was set to 9px

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Ready to be merged

<!-- feel free to add additional comments -->
