### PR TITLE
feat: cards can have custom bg colour

### DIFF
--- a/packages/cms/schemas/objects/pageCard.js
+++ b/packages/cms/schemas/objects/pageCard.js
@@ -62,5 +62,19 @@ export default {
       initialValue: 'dark',
       validation: (rule) => rule.required(),
     },
+    {
+      name: 'backgroundColor',
+      title: 'Background Colour',
+      description:
+        'The entered value should be in any valid HEX format, e.g. #EF5632, #ef5632, #EF5632A1, #ef5632a1, #ffe, #ffea',
+      type: 'string',
+      initialValue: '#FFF',
+      validation: (Rule) =>
+        Rule.custom((input) =>
+          /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{4}){1,2}$/i.test(input)
+            ? true
+            : 'Invalid HEX code!'
+        ),
+    },
   ],
 }

--- a/packages/cms/schemas/objects/pageCard.js
+++ b/packages/cms/schemas/objects/pageCard.js
@@ -71,6 +71,10 @@ export default {
       initialValue: '#FFF',
       validation: (Rule) =>
         Rule.custom((input) =>
+        /**
+         * original regex found here: 
+         * https://stackoverflow.com/questions/8027423/how-to-check-if-a-string-is-a-valid-hex-color-representation
+         */
           /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{4}){1,2}$/i.test(input)
             ? true
             : 'Invalid HEX code!'

--- a/packages/web/src/client/components/Cards/CardHome.tsx
+++ b/packages/web/src/client/components/Cards/CardHome.tsx
@@ -79,7 +79,7 @@ const CardHomeInner = ({
 }
 
 export const CardHome = (props: CardHomeProps) => {
-  const { slug, type, status, className, theme } = props
+  const { slug, type, status, className, theme, backgroundColor } = props
 
   const [styles, api] = useSpring(
     () => ({
@@ -127,7 +127,14 @@ export const CardHome = (props: CardHomeProps) => {
 
   return (
     <Link href={getHrefSlugFromSanityReference({ _type: type, slug })} passHref>
-      <CardWrapper className={className} theme={theme} {...bind()}>
+      <CardWrapper
+        className={className}
+        theme={theme}
+        css={{
+          backgroundColor,
+        }}
+        {...bind()}
+      >
         <CardHomeInner {...props} style={styles} />
       </CardWrapper>
     </Link>
@@ -144,8 +151,6 @@ const CardWrapper = styled('a', {
     theme: {
       [ThemeTypes.OUTLINED]: {},
       [ThemeTypes.LIGHT]: {
-        backgroundColor: '$white100',
-
         hover: {
           [`& ${ButtonContainer}`]: {
             backgroundColor: '$white50',
@@ -153,8 +158,6 @@ const CardWrapper = styled('a', {
         },
       },
       [ThemeTypes.GREY]: {
-        backgroundColor: '$white50',
-
         hover: {
           [`& ${ButtonContainer}`]: {
             backgroundColor: '$white50',
@@ -162,8 +165,6 @@ const CardWrapper = styled('a', {
         },
       },
       [ThemeTypes.DARK]: {
-        backgroundColor: '$black100',
-
         hover: {
           [`& ${ButtonContainer}`]: {
             backgroundColor: '$white50',

--- a/packages/web/src/data/queries/objects/card.ts
+++ b/packages/web/src/data/queries/objects/card.ts
@@ -8,5 +8,7 @@ export const CARD = groq`
     cardButtonLabel,
     media {
         ${MEDIA}
-    }
+    },
+    theme,
+    backgroundColor
 `

--- a/packages/web/src/types/sanity.generated.ts
+++ b/packages/web/src/types/sanity.generated.ts
@@ -15,7 +15,7 @@ import type {
   SanityImageDimensions,
   SanityImagePalette,
   SanityImagePaletteSwatch,
-} from 'sanity-codegen'
+} from "sanity-codegen";
 
 export type {
   SanityReference,
@@ -34,7 +34,7 @@ export type {
   SanityImageDimensions,
   SanityImagePalette,
   SanityImagePaletteSwatch,
-}
+};
 
 /**
  * Project
@@ -42,35 +42,35 @@ export type {
  *
  */
 export interface Project extends SanityDocument {
-  _type: 'project'
+  _type: "project";
 
   /**
    * Title — `string`
    *
    *
    */
-  title?: string
+  title?: string;
 
   /**
    * Slug — `slug`
    *
    *
    */
-  slug?: { _type: 'slug'; current: string }
+  slug?: { _type: "slug"; current: string };
 
   /**
    * Status — `string`
    *
    *
    */
-  status?: 'comingSoon' | 'live'
+  status?: "comingSoon" | "live";
 
   /**
    * Team — `array`
    *
    *
    */
-  team?: Array<SanityKeyedReference<TeamMember>>
+  team?: Array<SanityKeyedReference<TeamMember>>;
 
   /**
    * Page blocks — `array`
@@ -81,21 +81,21 @@ export interface Project extends SanityDocument {
     | SanityKeyed<BlockMedia>
     | SanityKeyed<BlockText>
     | SanityKeyed<BlockTestimonial>
-  >
+  >;
 
   /**
    * Page meta — `meta`
    *
    *
    */
-  meta?: Meta
+  meta?: Meta;
 
   /**
    * Page Card — `pageCard`
    *
    *
    */
-  card?: PageCard
+  card?: PageCard;
 }
 
 /**
@@ -104,21 +104,21 @@ export interface Project extends SanityDocument {
  *
  */
 export interface TeamMember extends SanityDocument {
-  _type: 'teamMember'
+  _type: "teamMember";
 
   /**
    * Name — `string`
    *
    *
    */
-  name?: string
+  name?: string;
 
   /**
    * Job Title — `string`
    *
    *
    */
-  job?: string
+  job?: string;
 
   /**
    * Image — `image`
@@ -126,11 +126,11 @@ export interface TeamMember extends SanityDocument {
    * Ensure this has a transparent background
    */
   image?: {
-    _type: 'image'
-    asset: SanityReference<SanityImageAsset>
-    crop?: SanityImageCrop
-    hotspot?: SanityImageHotspot
-  }
+    _type: "image";
+    asset: SanityReference<SanityImageAsset>;
+    crop?: SanityImageCrop;
+    hotspot?: SanityImageHotspot;
+  };
 }
 
 /**
@@ -139,14 +139,14 @@ export interface TeamMember extends SanityDocument {
  *
  */
 export interface Approachpage extends SanityDocument {
-  _type: 'approachpage'
+  _type: "approachpage";
 
   /**
    * Slug — `slug`
    *
    *
    */
-  slug?: { _type: 'slug'; current: string }
+  slug?: { _type: "slug"; current: string };
 
   /**
    * Sections — `array`
@@ -155,36 +155,36 @@ export interface Approachpage extends SanityDocument {
    */
   sections?: Array<
     SanityKeyed<{
-      _type: 'section'
+      _type: "section";
       /**
        * Text Block — `richText`
        *
        *
        */
-      text?: RichText
+      text?: RichText;
 
       /**
        * Media Section — `media`
        *
        *
        */
-      media?: Media
+      media?: Media;
     }>
-  >
+  >;
 
   /**
    * Page meta — `meta`
    *
    *
    */
-  meta?: Meta
+  meta?: Meta;
 
   /**
    * Page Card — `pageCard`
    *
    *
    */
-  card?: PageCard
+  card?: PageCard;
 }
 
 /**
@@ -193,14 +193,14 @@ export interface Approachpage extends SanityDocument {
  *
  */
 export interface Homepage extends SanityDocument {
-  _type: 'homepage'
+  _type: "homepage";
 
   /**
    * Standfirst — `richText`
    *
    *
    */
-  standfirst?: RichText
+  standfirst?: RichText;
 
   /**
    * Cards — `array`
@@ -211,14 +211,14 @@ export interface Homepage extends SanityDocument {
     SanityKeyedReference<
       Homepage | Teampage | Approachpage | Linktree | Project
     >
-  >
+  >;
 
   /**
    * Page meta — `meta`
    *
    *
    */
-  meta?: Meta
+  meta?: Meta;
 }
 
 /**
@@ -227,21 +227,21 @@ export interface Homepage extends SanityDocument {
  *
  */
 export interface Settings extends SanityDocument {
-  _type: 'settings'
+  _type: "settings";
 
   /**
    * Default meta — `meta`
    *
    *
    */
-  meta?: Meta
+  meta?: Meta;
 
   /**
    * Navigation — `array`
    *
    *
    */
-  navigation?: Array<SanityKeyed<Link>>
+  navigation?: Array<SanityKeyed<Link>>;
 
   /**
    * Callout — `object`
@@ -249,28 +249,28 @@ export interface Settings extends SanityDocument {
    *
    */
   callout?: {
-    _type: 'callout'
+    _type: "callout";
     /**
      * Text — `text`
      *
      *
      */
-    text?: string
+    text?: string;
 
     /**
      * Link — `link`
      *
      * When clicked the callout links to...?
      */
-    link?: Link
+    link?: Link;
 
     /**
      * Media — `media`
      *
      *
      */
-    media?: Media
-  }
+    media?: Media;
+  };
 
   /**
    * Footer — `object`
@@ -278,21 +278,21 @@ export interface Settings extends SanityDocument {
    *
    */
   footer?: {
-    _type: 'footer'
+    _type: "footer";
     /**
      * Links — `array`
      *
      *
      */
-    links?: Array<SanityKeyed<Link>>
-  }
+    links?: Array<SanityKeyed<Link>>;
+  };
 
   /**
    * Redirects — `redirects`
    *
    *
    */
-  redirects?: Redirects
+  redirects?: Redirects;
 }
 
 /**
@@ -301,14 +301,14 @@ export interface Settings extends SanityDocument {
  *
  */
 export interface Teampage extends SanityDocument {
-  _type: 'teampage'
+  _type: "teampage";
 
   /**
    * Slug — `slug`
    *
    *
    */
-  slug?: { _type: 'slug'; current: string }
+  slug?: { _type: "slug"; current: string };
 
   /**
    * Slideshow — `array`
@@ -317,43 +317,43 @@ export interface Teampage extends SanityDocument {
    */
   slideshow?: Array<
     SanityKeyed<{
-      _type: 'slide'
+      _type: "slide";
       /**
        * Media — `media`
        *
        *
        */
-      media?: Media
+      media?: Media;
 
       /**
        * Rotation — `number`
        *
        *
        */
-      rotation?: number
+      rotation?: number;
     }>
-  >
+  >;
 
   /**
    * Text Block — `richText`
    *
    *
    */
-  textBlockOne?: RichText
+  textBlockOne?: RichText;
 
   /**
    * Team — `array`
    *
    *
    */
-  team?: Array<SanityKeyedReference<TeamMember>>
+  team?: Array<SanityKeyedReference<TeamMember>>;
 
   /**
    * Text Block — `richText`
    *
    *
    */
-  textBlockTwo?: RichText
+  textBlockTwo?: RichText;
 
   /**
    * Qualities — `array`
@@ -362,36 +362,36 @@ export interface Teampage extends SanityDocument {
    */
   qualities?: Array<
     SanityKeyed<{
-      _type: 'quality'
+      _type: "quality";
       /**
        * Media — `media`
        *
        *
        */
-      media?: Media
+      media?: Media;
 
       /**
        * Text — `richText`
        *
        *
        */
-      text?: RichText
+      text?: RichText;
     }>
-  >
+  >;
 
   /**
    * Page meta — `meta`
    *
    *
    */
-  meta?: Meta
+  meta?: Meta;
 
   /**
    * Page Card — `pageCard`
    *
    *
    */
-  card?: PageCard
+  card?: PageCard;
 }
 
 /**
@@ -400,7 +400,7 @@ export interface Teampage extends SanityDocument {
  *
  */
 export interface Linktree extends SanityDocument {
-  _type: 'linktree'
+  _type: "linktree";
 
   /**
    * Links — `array`
@@ -409,29 +409,29 @@ export interface Linktree extends SanityDocument {
    */
   links?: Array<
     SanityKeyed<{
-      _type: 'item'
+      _type: "item";
       /**
        * Link — `link`
        *
        *
        */
-      link?: Link
+      link?: Link;
 
       /**
        * Media — `media`
        *
        *
        */
-      media?: Media
+      media?: Media;
     }>
-  >
+  >;
 
   /**
    * Page meta — `meta`
    *
    *
    */
-  meta?: Meta
+  meta?: Meta;
 }
 
 /**
@@ -440,45 +440,45 @@ export interface Linktree extends SanityDocument {
  *
  */
 export interface Privacy extends SanityDocument {
-  _type: 'privacy'
+  _type: "privacy";
 
   /**
    * Content — `richText`
    *
    *
    */
-  content?: RichText
+  content?: RichText;
 
   /**
    * Page meta — `meta`
    *
    *
    */
-  meta?: Meta
+  meta?: Meta;
 
   /**
    * Page Card — `pageCard`
    *
    *
    */
-  card?: PageCard
+  card?: PageCard;
 }
 
 export type Media = {
-  _type: 'media'
+  _type: "media";
   /**
    * Asset type — `string`
    *
    *
    */
-  assetType?: 'image' | 'video'
+  assetType?: "image" | "video";
 
   /**
    * Video file — `mux.video`
    *
    *
    */
-  video?: MuxVideo
+  video?: MuxVideo;
 
   /**
    * Image file — `image`
@@ -486,24 +486,24 @@ export type Media = {
    *
    */
   image?: {
-    _type: 'image'
-    asset: SanityReference<SanityImageAsset>
-    crop?: SanityImageCrop
-    hotspot?: SanityImageHotspot
-  }
-}
+    _type: "image";
+    asset: SanityReference<SanityImageAsset>;
+    crop?: SanityImageCrop;
+    hotspot?: SanityImageHotspot;
+  };
+};
 
-export type RichText = Array<SanityKeyed<SanityBlock>>
+export type RichText = Array<SanityKeyed<SanityBlock>>;
 
 export type Meta = {
-  _type: 'meta'
+  _type: "meta";
   /**
    * SEO — `seo-tools`
    *
    *
    */
-  seo?: SeoTools
-}
+  seo?: SeoTools;
+};
 
 export type Redirects = Array<
   SanityKeyed<{
@@ -512,77 +512,84 @@ export type Redirects = Array<
      *
      *
      */
-    source?: string
+    source?: string;
 
     /**
      * New URL — `string`
      *
      *
      */
-    destination?: string
+    destination?: string;
 
     /**
      * Permanent — `boolean`
      *
      *
      */
-    permanent?: boolean
+    permanent?: boolean;
   }>
->
+>;
 
 export type PageCard = {
-  _type: 'pageCard'
+  _type: "pageCard";
   /**
    * Card Title — `string`
    *
    * If omitted, the SEO title will be used
    */
-  title?: string
+  title?: string;
 
   /**
    * Subtitle — `string`
    *
    *
    */
-  subtitle?: string
+  subtitle?: string;
 
   /**
    * Media — `media`
    *
    * If omitted, the SEO media will be used
    */
-  media?: Media
+  media?: Media;
 
   /**
    * Card Button Label — `string`
    *
    *
    */
-  cardButtonLabel?: string
+  cardButtonLabel?: string;
 
   /**
    * Theme — `string`
    *
    *
    */
-  theme?: 'light' | 'grey' | 'dark'
-}
+  theme?: "light" | "grey" | "dark";
+
+  /**
+   * Background Colour — `string`
+   *
+   * The entered value should be in HEX format, e.g. ef5632
+   */
+  backgroundColor?: string;
+};
 
 export type Link = {
-  _type: 'link'
+  _type: "link";
   /**
    * Label — `string`
    *
    * If omitted, the title of the reference will be used
    */
-  label?: string
+  label?: string;
 
   /**
    * Link Type — `string`
    *
    * Are you linking to an internal or external page?
    */
-  linkType?: 'internal' | 'external'
+  linkType?: "internal" | "external";
 
   /**
    * Link Internal — `reference`
@@ -591,38 +598,38 @@ export type Link = {
    */
   linkInternal?: SanityReference<
     Homepage | Teampage | Approachpage | Linktree | Project
-  >
+  >;
 
   /**
    * Link External — `url`
    *
    *
    */
-  linkExternal?: string
-}
+  linkExternal?: string;
+};
 
 export type BlockMedia = {
-  _type: 'blockMedia'
+  _type: "blockMedia";
   /**
    * Layout — `string`
    *
    *
    */
-  layout?: 'full' | 'half' | '2/3'
+  layout?: "full" | "half" | "2/3";
 
   /**
    * Is Hero? — `boolean`
    *
    *
    */
-  isHero?: boolean
+  isHero?: boolean;
 
   /**
    * Background Color — `string`
    *
    *
    */
-  backgroundColor?: string
+  backgroundColor?: string;
 
   /**
    * Background Image — `image`
@@ -630,11 +637,11 @@ export type BlockMedia = {
    *
    */
   backgroundImage?: {
-    _type: 'image'
-    asset: SanityReference<SanityImageAsset>
-    crop?: SanityImageCrop
-    hotspot?: SanityImageHotspot
-  }
+    _type: "image";
+    asset: SanityReference<SanityImageAsset>;
+    crop?: SanityImageCrop;
+    hotspot?: SanityImageHotspot;
+  };
 
   /**
    * Media Items — `array`
@@ -643,64 +650,64 @@ export type BlockMedia = {
    */
   items?: Array<
     SanityKeyed<{
-      _type: 'item'
+      _type: "item";
       /**
        * Has Mobile Asset? — `boolean`
        *
        *
        */
-      hasMobile?: boolean
+      hasMobile?: boolean;
 
       /**
        * Mobile Asset — `media`
        *
        *
        */
-      mobile?: Media
+      mobile?: Media;
 
       /**
        * Desktop Asset — `media`
        *
        *
        */
-      desktop?: Media
+      desktop?: Media;
 
       /**
        * Caption — `string`
        *
        *
        */
-      caption?: string
+      caption?: string;
     }>
-  >
-}
+  >;
+};
 
 export type BlockText = {
-  _type: 'blockText'
+  _type: "blockText";
   /**
    * Text — `richText`
    *
    *
    */
-  richText?: RichText
-}
+  richText?: RichText;
+};
 
 export type BlockTestimonial = {
-  _type: 'blockTestimonial'
+  _type: "blockTestimonial";
   /**
    * Quote — `richText`
    *
    *
    */
-  quote?: RichText
+  quote?: RichText;
 
   /**
    * Author — `string`
    *
    *
    */
-  author?: string
-}
+  author?: string;
+};
 
 export type Documents =
   | Project
@@ -710,18 +717,18 @@ export type Documents =
   | Settings
   | Teampage
   | Linktree
-  | Privacy
+  | Privacy;
 
 /**
  * This interface is a stub. It was referenced in your sanity schema but
  * the definition was not actually found. Future versions of
  * sanity-codegen will let you type this explicity.
  */
-type MuxVideo = any
+type MuxVideo = any;
 
 /**
  * This interface is a stub. It was referenced in your sanity schema but
  * the definition was not actually found. Future versions of
  * sanity-codegen will let you type this explicity.
  */
-type SeoTools = any
+type SeoTools = any;


### PR DESCRIPTION
## the colour is being passed through sanity, where it is also verified as a valid HEX code

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
Resolves #192 

### What

<!-- what have you done, if its a bug, whats your solution? -->
- added `backgroundColor` property in the page card component in the cms
- applied HEX code validation, that shows a warning message in case a code that is submitted is not valid - this way the user knows why they cannot publish the document in case that happens.
 _Note_: 8 or 4-digit HEX codes are also valid here to include the alpha channel
- passed the background colour value into the component in the FE and used inline css to apply it

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Ready to be merged

<!-- feel free to add additional comments -->
