### PR TITLE
Fix/202

### DIFF
--- a/packages/web/src/client/components/Cards/CardHome.tsx
+++ b/packages/web/src/client/components/Cards/CardHome.tsx
@@ -34,6 +34,7 @@ const CardHomeInner = ({
   cardButtonLabel = 'View',
   status,
   style,
+  backgroundColor,
 }: CardHomeInnerProps) => {
   const selectedMedia = media?.asset
     ? media
@@ -45,6 +46,11 @@ const CardHomeInner = ({
 
   return (
     <>
+      <BackgroundColor
+        style={{
+          backgroundColor,
+        }}
+      />
       <ImageContainer style={style}>
         {selectedMedia ? (
           <MediaContainer controls={false} {...selectedMedia} />
@@ -81,7 +87,7 @@ const CardHomeInner = ({
 }
 
 export const CardHome = (props: CardHomeProps) => {
-  const { slug, type, status, className, theme, backgroundColor } = props
+  const { slug, type, status, className, theme } = props
 
   const [styles, api] = useSpring(
     () => ({
@@ -129,14 +135,7 @@ export const CardHome = (props: CardHomeProps) => {
 
   return (
     <Link href={getHrefSlugFromSanityReference({ _type: type, slug })} passHref>
-      <CardWrapper
-        className={className}
-        theme={theme}
-        css={{
-          backgroundColor,
-        }}
-        {...bind()}
-      >
+      <CardWrapper className={className} theme={theme} {...bind()}>
         <CardHomeInner {...props} style={styles} />
       </CardWrapper>
     </Link>
@@ -146,7 +145,7 @@ export const CardHome = (props: CardHomeProps) => {
 const CardWrapper = styled('a', {
   display: 'block',
   position: 'relative',
-  br: '$wrapperLarge',
+  borderRadius: '$wrapperLarge',
   overflow: 'hidden',
 
   variants: {
@@ -177,13 +176,23 @@ const CardWrapper = styled('a', {
   },
 })
 
+const BackgroundColor = styled('div', {
+  width: '100%',
+  height: '100%',
+  position: 'absolute',
+  inset: 0,
+  zIndex: -1,
+  borderRadius: '$wrapperLarge',
+  transformOrigin: '50% 50%',
+  transform: 'scale(0.998)',
+})
+
 const ImageContainer = styled(animated.div, {
   transformOrigin: '50% 50%',
 })
 
 const MediaContainer = styled(Media, {
   br: '$wrapperLarge',
-  overflow: 'hidden',
 })
 
 const CardText = styled('div', {

--- a/packages/web/src/client/components/Media/Media.tsx
+++ b/packages/web/src/client/components/Media/Media.tsx
@@ -31,7 +31,7 @@ export const Media = (props: MediaProps) => {
       display: 'block',
       content: '',
       width: '100%',
-      pt: `${aspectRatio}%`,
+      pt: `${Math.floor(aspectRatio)}%`,
     },
   }
 


### PR DESCRIPTION
### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

- resolves #202 

The actual bug only really seems to happen with the `video` element. Looking around there are a few suggestions to solve it but none of them accurately fix it. It reminds me of the bug we had in VanMoof where the clip path was off by 1px and looking around it seems to be a browser rendering issue with border-radius' because if you make them boxes the issue no longer prevails

### What

<!-- what have you done, if its a bug, whats your solution? -->

To solve the issue we scale the background color down by a fraction just so it's behind, I don't believe it's noticeable?

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- feel free to add additional comments -->
