### PR TITLE
fix: round aspect values to two decimal places

### DIFF
--- a/packages/web/src/client/components/Media/Media.tsx
+++ b/packages/web/src/client/components/Media/Media.tsx
@@ -31,7 +31,7 @@ export const Media = (props: MediaProps) => {
       display: 'block',
       content: '',
       width: '100%',
-      pt: `${Math.floor(aspectRatio)}%`,
+      pt: `${aspectRatio.toFixed(2)}%`,
     },
   }
 

--- a/packages/web/src/client/styles/stitches.config.ts
+++ b/packages/web/src/client/styles/stitches.config.ts
@@ -194,7 +194,7 @@ const { styled, globalCss, getCssText, config, keyframes, reset } =
           display: 'block',
           content: '',
           width: '100%',
-          paddingTop: `${h ? (h / w) * 100 : w}%`,
+          paddingTop: `${(h ? (h / w) * 100 : w).toFixed(2)}%`,
         },
 
         '& > *': {


### PR DESCRIPTION
### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

- resolves #215 

This bug was brought in when we were trying to resolve homepage cards having their backgrounds bleed.

### What

<!-- what have you done, if its a bug, whats your solution? -->

- rounds aspect ratio values to two fixed places in the Media component and the stitches util function.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- feel free to add additional comments -->
