### PR TITLE
fix: use useHover to dictate flex on larger than tablet

### DIFF
--- a/packages/web/src/client/components/Avatars/Avatars.tsx
+++ b/packages/web/src/client/components/Avatars/Avatars.tsx
@@ -50,45 +50,54 @@ export const Avatars = ({ members }: AvatarsProps) => {
 
   return (
     <GridWrapper>
-      {(members ?? []).map(({ image, name, job }, i) => (
-        <GridItemContainer
-          onMouseEnter={handleMouseEnter(i)}
-          onMouseLeave={handleMouseLeave(i)}
-          key={name}
-          css={{
-            mr: canHover ? 0 : '$s',
-          }}
-        >
-          {image ? <GridImageWrapper {...image} /> : null}
-          <TeamMemberDetails
-            ref={(ref) => (textRefs.current[i] = ref as HTMLDivElement)}
-            style={{ width: springs[i].width }}
+      <GridScrollWrapper
+        css={{
+          '@tabletUp': {
+            justifyContent: canHover ? 'flex-end' : 'flex-start',
+            py: canHover ? 0 : '$s',
+          },
+        }}
+      >
+        {(members ?? []).map(({ image, name, job }, i) => (
+          <GridItemContainer
+            onMouseEnter={handleMouseEnter(i)}
+            onMouseLeave={handleMouseLeave(i)}
+            key={name}
+            css={{
+              '& + &': {
+                ml: canHover ? 0 : '$s',
+              },
+            }}
           >
-            <TeamMemberHeading tag="h2" fontStyle="XS" weight="$bold">
-              {name}
-            </TeamMemberHeading>
-            <TeamMemberHeading tag="h3" fontStyle="XS">
-              {job}
-            </TeamMemberHeading>
-          </TeamMemberDetails>
-        </GridItemContainer>
-      ))}
+            {image ? <GridImageWrapper {...image} /> : null}
+            <TeamMemberDetails
+              ref={(ref) => (textRefs.current[i] = ref as HTMLDivElement)}
+              style={{ width: springs[i].width }}
+            >
+              <TeamMemberHeading tag="h2" fontStyle="XS" weight="$bold">
+                {name}
+              </TeamMemberHeading>
+              <TeamMemberHeading tag="h3" fontStyle="XS">
+                {job}
+              </TeamMemberHeading>
+            </TeamMemberDetails>
+          </GridItemContainer>
+        ))}
+      </GridScrollWrapper>
     </GridWrapper>
   )
 }
 
 const GridWrapper = styled('div', {
   width: '100%',
+})
+
+const GridScrollWrapper = styled('div', {
   display: 'flex',
   justifyContent: 'flex-start',
   alignItems: 'flex-end',
-  py: '$s',
   overflow: 'auto',
-
-  '@tabletUp': {
-    py: 0,
-    justifyContent: 'flex-end',
-  },
+  py: '$s',
 })
 
 const GridItemContainer = styled('div', {

--- a/packages/web/src/client/components/Headers/ProjectHeader.tsx
+++ b/packages/web/src/client/components/Headers/ProjectHeader.tsx
@@ -27,6 +27,7 @@ const Header = styled('header', {
   display: 'flex',
   justifyContent: 'space-between',
   flexDirection: 'column',
+  flexWrap: 'wrap',
 
   '@tabletUp': {
     mb: '$xs',


### PR DESCRIPTION
### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

- resolves #212 

On tabletUp we expect all devices to support hover events which is a false assumption.

### What

<!-- what have you done, if its a bug, whats your solution? -->

We can now wrap the `ProjectHeader` component and the styling to allow scrolling / padding is dictated by whether or not the device supports `hover` events

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- feel free to add additional comments -->
