### PR TITLE
fix: call play in event handler

### DIFF
--- a/packages/web/src/client/components/Blocks/BlocksCarousel/Video.tsx
+++ b/packages/web/src/client/components/Blocks/BlocksCarousel/Video.tsx
@@ -13,8 +13,8 @@ interface VideoProps {
 }
 
 export const Video = ({ video, setPaused, isPaused }: VideoProps) => {
-  const handleVideoClick = () => {
-    setPaused((s) => !s)
+  const handleVideoClick = (paused: boolean) => {
+    setPaused(paused)
   }
 
   const handleAutoplayCallback = useCallback((isPlaying: boolean) => {

--- a/packages/web/src/client/components/Video/VideoPlayer.tsx
+++ b/packages/web/src/client/components/Video/VideoPlayer.tsx
@@ -12,7 +12,7 @@ export type VideoPlayerProps = {
   poster?: string
   isPaused?: boolean
   onAutoplayCallback?: (isPlaying: boolean) => void
-  onClick?: () => void
+  onClick?: (isPaused: boolean) => void
   controls?: boolean
 }
 
@@ -46,24 +46,6 @@ export const VideoPlayer = ({
   )
 
   /**
-   * Play/Pause handling
-   */
-  useEffect(() => {
-    /**
-     * If it's not paused and intersecting,
-     * play the video
-     */
-    if (!isPaused && isIntersecting) {
-      videoRef.current.play()
-    } else if (isPaused) {
-      /**
-       * Else if it pause, pause it
-       */
-      videoRef.current.pause()
-    }
-  }, [isIntersecting, isPaused])
-
-  /**
    * Autoplay effect handling
    */
   useEffect(() => {
@@ -76,7 +58,9 @@ export const VideoPlayer = ({
       /**
        * Otherwise outplay in the frame
        */
-      videoRef.current.play()
+      videoRef.current.play().catch((e) => {
+        console.error('Cant autoplay because:', e)
+      })
     }
 
     if (onAutoplayCallback) {
@@ -118,8 +102,33 @@ export const VideoPlayer = ({
   }, [src])
 
   const handleClick = () => {
-    if (onClick) {
-      onClick()
+    const video = videoRef.current
+
+    if (isPaused) {
+      /**
+       * Play is async so catch just incase
+       * and return if its paused or not
+       * to keep ui in sync with video element
+       */
+      video
+        .play()
+        .then(() => {
+          if (onClick) {
+            onClick(false)
+          }
+        })
+        .catch((e) => {
+          console.error('Failed to play because:', e)
+          if (onClick) {
+            onClick(true)
+          }
+        })
+    } else {
+      video.pause()
+
+      if (onClick) {
+        onClick(true)
+      }
     }
   }
 


### PR DESCRIPTION
won't work in async function

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

- resolves #246 

### What

<!-- what have you done, if its a bug, whats your solution? -->

The issue is `play` in low battery mode will *only* work if called in an event handler

Because were assuming that the play button would always work so the state informed the elements state, `play` was called in an effect - async code, this was the wrong way round so it has now been reversed so the state of the element informs the state of the UI and the `play` method is called in the event handler.

Also suppress the stupid error that it can't autoplay because LBM.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- feel free to add additional comments -->
