### PR TITLE
fix: removed flex from global html

### DIFF
--- a/packages/web/src/client/components/LinkTree/Layout.tsx
+++ b/packages/web/src/client/components/LinkTree/Layout.tsx
@@ -34,7 +34,7 @@ const LinkTreeContainer = styled('main', {
   position: 'relative',
   display: 'flex',
   justifyContent: 'center',
-  height: '100%',
+  height: '100vh',
   backgroundColor: '$orange100',
 })
 

--- a/packages/web/src/client/styles/global.ts
+++ b/packages/web/src/client/styles/global.ts
@@ -41,7 +41,6 @@ export const globalStyles = globalCss({
   },
 
   html: {
-    display: 'flex',
     scrollBehavior: 'smooth',
   },
 


### PR DESCRIPTION
### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->
- removed flex from global styles
- made `/instagram` page to have `height: 100vh` so the whole page is orange in background

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Ready to be merged

<!-- feel free to add additional comments -->
